### PR TITLE
resolve redirect issues

### DIFF
--- a/app/controllers/works_controller.rb
+++ b/app/controllers/works_controller.rb
@@ -76,13 +76,12 @@ class WorksController < ApplicationController
       else
         flash[:result_text] = "Could not upvote"
         flash[:messages] = vote.errors.messages
-        status = 302
       end
     else
       flash[:result_text] = "You must log in to do that"
       # There is a long web standards debate about returning contents with a 401 status code
-      # but you cannot auto-redirect without a 30x status code, hence using 302 here (and above).
-      status = 302
+      # but you cannot auto-redirect without a 30x status code, hence using the default redirect here
+      # (and above) via no special status code.
     end
 
     # Refresh the page to show either the updated vote count


### PR DESCRIPTION
We cannot do any (automatic) redirects with 4xx status codes so switched them for user experience purposes.

Related to trello card: https://trello.com/c/BzqyIeWq/451-c9-fix-bugs-on-media-ranker-20